### PR TITLE
Make legend optional and add axis value (limited functionality)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ notifications:
 matrix:
   include:
   - rvm: 2.0.0
-    gemfile: gemfiles/Gemfile.activesupport-3.x
-  - rvm: 2.2.2
-    gemfile: gemfiles/Gemfile.activesupport-4.x

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ How to install
 
 Squid requires **Ruby 2.0 or higher**.
 To include in your project, add `gem 'squid', '~> 0.1.0'` to the `Gemfile` file of your Ruby project.
+If used in a Rails project, requires **Rails 4.0 or higher**.
 
 How to use
 ==========

--- a/gemfiles/Gemfile.activesupport-3.x
+++ b/gemfiles/Gemfile.activesupport-3.x
@@ -1,4 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'activesupport', '~> 3.0'
-gemspec path: '../'

--- a/gemfiles/Gemfile.activesupport-4.x
+++ b/gemfiles/Gemfile.activesupport-4.x
@@ -1,4 +1,0 @@
-source 'http://rubygems.org'
-
-gem 'activesupport', '~> 4.0'
-gemspec path: '../'

--- a/lib/squid.rb
+++ b/lib/squid.rb
@@ -1,7 +1,9 @@
 require 'prawn'
 
+require 'active_support' # Active Support does not load anything by default
 require 'active_support/core_ext/string/inflections' # for titleize
 require 'active_support/core_ext/object/inclusion' # for in?
+require 'active_support/number_helper' # for number_to_rounded
 
 require 'squid/config'
 require 'squid/interface'

--- a/lib/squid/base.rb
+++ b/lib/squid/base.rb
@@ -30,5 +30,11 @@ module Squid
       stroke { yield }
       old_values.each{|k, old_value| public_send "#{k}=", old_value }
     end
+
+    # Default options for text elements (labels, categories, ...)
+    def text_options
+      {size: 8, valign: :center, overflow: :shrink_to_fit, disable_wrap_by_char: true}
+    end
+
   end
 end

--- a/lib/squid/configuration.rb
+++ b/lib/squid/configuration.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 module Squid
   # Provides an object to store global configuration settings.
   #
@@ -27,13 +29,14 @@ module Squid
   #
   class Configuration < OpenStruct
     # @return [Integer] the default graph height
-    attr_accessor :baseline, :gridlines, :height
+    attr_accessor :baseline, :gridlines, :height, :legend
 
     # Initialize the global configuration settings, using the values of
     # the specified following environment variables by default.
     def initialize
       @baseline = ENV.fetch('SQUID_BASELINE', 'true').in? %w(1 t T true TRUE)
-      @gridlines = ENV.fetch('SQUID_GRIDLINES', '5').to_i
+      @legend = ENV.fetch('SQUID_LEGEND', 'true').in? %w(1 t T true TRUE)
+      @gridlines = ENV.fetch('SQUID_GRIDLINES', '4').to_i
       @height = ENV.fetch('SQUID_HEIGHT', '200').to_f
     end
   end

--- a/lib/squid/graph.rb
+++ b/lib/squid/graph.rb
@@ -1,4 +1,5 @@
 require 'squid/base'
+require 'squid/graph/axis_value'
 require 'squid/graph/gridline'
 require 'squid/graph/legend'
 
@@ -13,6 +14,7 @@ module Squid
 
         each_gridline do |options = {}|
           Gridline.new(pdf, {}, options).draw
+          AxisValue.new(pdf, max_min_values, options).draw
         end
 
         # The baseline is last so it’s drawn on top of any graph element.
@@ -29,6 +31,22 @@ module Squid
         y = bounds.top - height*index / gridlines
         yield width: bounds.width, y: y, fraction: fraction
       end if data.any? && gridlines > 0
+    end
+
+    # Returns the maximum and minimum values of each series.
+    def max_min_values
+      data.values.map do |series|
+        max = (series.values + [gridlines]).compact.max
+        min = (series.values + [0]).compact.min
+        [max, min].map{|value| approximate_value_for value}
+      end
+    end
+
+    # Returns an approximation of a value that looks nicer on a graph axis.
+    # For instance, rounds 99.67 to 100, which makes for a better axis value.
+    def approximate_value_for(value)
+      options = {significant: true, precision: 2}
+      ActiveSupport::NumberHelper.number_to_rounded(value, options).to_f
     end
   end
 end

--- a/lib/squid/graph.rb
+++ b/lib/squid/graph.rb
@@ -4,12 +4,12 @@ require 'squid/graph/legend'
 
 module Squid
   class Graph < Base
-    has_settings :baseline, :gridlines, :height
+    has_settings :baseline, :gridlines, :height, :legend
 
     # Draws the graph.
     def draw
       bounding_box [0, cursor], width: bounds.width, height: height do
-        Legend.new(pdf, data.keys).draw
+        Legend.new(pdf, data.keys).draw if legend
 
         each_gridline do |options = {}|
           Gridline.new(pdf, {}, options).draw
@@ -25,10 +25,10 @@ module Squid
     # Yields the block once for each gridline, setting +y+ appropriately.
     def each_gridline
       0.upto(gridlines) do |index|
-        fraction = gridlines.zero? ? 0 : (gridlines - index) / gridlines.to_f
-        y = gridlines.zero? ? 0 : bounds.top - height*index / gridlines
+        fraction = (gridlines - index) / gridlines.to_f
+        y = bounds.top - height*index / gridlines
         yield width: bounds.width, y: y, fraction: fraction
-      end
+      end if data.any? && gridlines > 0
     end
   end
 end

--- a/lib/squid/graph/axis_value.rb
+++ b/lib/squid/graph/axis_value.rb
@@ -1,0 +1,39 @@
+require 'squid/base'
+
+module Squid
+  # Adds a single value label to the axis of a graph. The :format option can
+  # be used to specify the format of the label (currency, percentage, ...).
+  class AxisValue < Base
+    def draw
+      text_box label, label_options
+    end
+
+  private
+
+    # The label formats the value based on the :format option.
+    def label
+      value.to_s
+    end
+
+    def label_options
+      text_options.merge height: height, at: [bounds.left, y]
+    end
+
+    # The actual value is calculated by considering the minimum and maximum
+    # values for the axis and which value the label represents (fraction).
+    def value
+      max_value, min_value = @data.first
+      (max_value - min_value) * @settings[:fraction] + min_value
+    end
+
+    # The vertical position where the value should be drawn.
+    def y
+      @settings[:y] + height/2
+    end
+
+    # The height of each axis label
+    def height
+      20
+    end
+  end
+end

--- a/manual/squid/baseline.rb
+++ b/manual/squid/baseline.rb
@@ -1,9 +1,9 @@
 # By default, <code>chart</code> plots a baseline at the bottom of the graph.
+#
 # You can use the <code>:baseline</code> option to disable this behavior.
 #
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   data = {views: {2013 => 182, 2014 => 46, 2015 => 102}}
-  text 'Without baseline:'
   chart data, baseline: false
 end

--- a/manual/squid/basic.rb
+++ b/manual/squid/basic.rb
@@ -1,7 +1,6 @@
 # Creating graphs with Squid is easy. Just use the <code>chart</code> method.
 #
-# The most simple graph can be created by providing only a hash containing
-# the data of the series you want to plot.
+# Provide a hash containing the data of the series and plot it with <code>chart</code>.
 #
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do

--- a/manual/squid/gridlines.rb
+++ b/manual/squid/gridlines.rb
@@ -1,9 +1,9 @@
 # By default, <code>chart</code> plots 5 equidistant horizontal gridlines.
+#
 # You can use the <code>:gridlines</code> option to change this number.
 #
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   data = {views: {2013 => 182, 2014 => 46, 2015 => 102}}
-  text 'With 2 gridlines:'
   chart data, gridlines: 2
 end

--- a/manual/squid/height.rb
+++ b/manual/squid/height.rb
@@ -1,9 +1,9 @@
 # By default, <code>chart</code> generates charts with a height of 200.
+#
 # You can use the <code>:height</code> option to manually set the height.
 #
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   data = {views: {2013 => 182, 2014 => 46, 2015 => 102}}
-  text 'With custom height:'
   chart data, height: 300
 end

--- a/manual/squid/legend.rb
+++ b/manual/squid/legend.rb
@@ -1,11 +1,9 @@
-# By default, <code>chart</code> adds a legend in the top-right corner of the chart,
-# listing the labels of all the series in the graph.
+# By default, <code>chart</code> adds a legend in the top-right corner.
+#
+# You can use the <code>:legend</code> option to disable this behavior.
 #
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
-  views = {2013 => 182, 2014 => 46, 2015 => 102}
-  uniques = {2013 => 110, 2014 => 30, 2015 => 88}
-
-  text 'Without two series:'
-  chart views: views, uniques: uniques
+  data = {views: {2013 => 182, 2014 => 46, 2015 => 102}}
+  chart data, legend: false
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -14,6 +14,7 @@ describe Squid::Configuration do
     it 'can be set with the environment variable SQUID_BASELINE' do
       ENV['SQUID_BASELINE'] = baseline
       expect(config.baseline).to be false
+      ENV['SQUID_BASELINE'] = nil
     end
   end
 
@@ -28,6 +29,7 @@ describe Squid::Configuration do
     it 'can be set with the environment variable SQUID_HEIGHT' do
       ENV['SQUID_HEIGHT'] = height.to_s
       expect(config.height).to eq height
+      ENV['SQUID_HEIGHT'] = nil
     end
   end
 end

--- a/spec/graph/axis_value_spec.rb
+++ b/spec/graph/axis_value_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe 'Graph axis values', inspect: true do
+  before { pdf.chart data, options.merge(legend: false) }
+
+  context 'given no series, does not print any axis value' do
+    it { expect(inspected_strings).to be_empty }
+  end
+
+  context 'given one series' do
+    let(:data) { {subscribers: subscribers} }
+
+    context 'by default' do
+      it 'are gridlines + 1 (for the baseline)' do
+        expect(inspected_strings.size).to be 5
+      end
+
+      it 'start with the series maximum' do
+        expect(inspected_strings.first.to_i).to eq subscribers.values.max
+      end
+
+      it 'end with the series minimum' do
+        expect(inspected_strings.last.to_i).to eq subscribers.values.min
+      end
+
+      it 'range equidistant values from the series minimum to maximum' do
+        distance = inspected_strings.map(&:to_f).each_cons(2).map {|a, b| a - b}
+        expect(distance.uniq).to be_one
+      end
+
+      it 'are positioned along the equidistant horizontal gridlines' do
+        left_point = inspected_text.positions.map &:first
+        expect(left_point.uniq).to be_one
+
+        distance = inspected_text.positions.each_cons(2).map do |x|
+          (x.first.last - x.last.last).round(2)
+        end
+        expect(distance.uniq).to be_one
+      end
+
+    end
+
+    context 'given the series minimum is greater than zero' do
+      let(:subscribers) { {2013 => 50, 2014 => 30, 2015 => 20} }
+
+      it 'ends with zero' do
+        expect(inspected_strings.last.to_i).to be_zero
+      end
+    end
+
+    context 'given the series maximum is lower than the number of gridlines' do
+      let(:subscribers) { {2013 => 1, 2014 => 2, 2015 => 2} }
+
+      it 'starts with the number of gridlines' do
+        expect(inspected_strings.first.to_i).to eq 4
+      end
+    end
+
+    context 'given the axis values have more than 2 significant digits' do
+      let(:subscribers) { {2013 => 182, 2014 => 46, 2015 => 102} }
+
+      it 'displays the axis values rounded to 2 significant digits' do
+        expect(inspected_strings).to eq %w(180.0 135.0 90.0 45.0 0.0)
+      end
+    end
+
+    context 'given the series has nil values' do
+      let(:subscribers) { {2013 => -50, 2014 => nil, 2015 => 20} }
+
+      it 'ignores nil values' do
+        expect(inspected_strings.first.to_i).to be 20
+        expect(inspected_strings.last.to_i).to be -50
+      end
+    end
+
+    context 'given a :gridlines option' do
+      let(:options) { {gridlines: 2} }
+
+      it 'renders as many axis value labels as gridlines' do
+
+      end
+    end
+  end
+end

--- a/spec/graph/gridlines_spec.rb
+++ b/spec/graph/gridlines_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe 'Graph gridlines', inspect: true do
   before { pdf.chart data, options.merge(baseline: false) }
 
-  # context 'given no series, does not print any gridline' do
-  #   it { expect(inspected_line.points).to be_empty }
-  # end
+  context 'given no series, does not print any gridline' do
+    it { expect(inspected_line.points).to be_empty }
+  end
 
   context 'given one or more series' do
     let(:data) { {views: views} }
@@ -26,5 +26,4 @@ describe 'Graph gridlines', inspect: true do
       expect(distance.uniq).to be_one
     end
   end
-
 end

--- a/spec/graph/legend_spec.rb
+++ b/spec/graph/legend_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
 describe 'Graph legend', inspect: true do
-  before { pdf.chart data, options }
+  before { pdf.chart data, options.merge(gridlines: 0) }
 
   context 'given no series, does not have any text' do
-    it { expect(inspected_text.strings).to be_empty }
+    it { expect(inspected_strings).to be_empty }
   end
 
   context 'given one series' do
     let(:data) { {views: views} }
 
     it 'includes the titleized name of the series' do
-      expect(inspected_text.strings).to eq ['Views']
+      expect(inspected_strings).to eq ['Views']
     end
 
     it 'draws a small square representing the series' do
@@ -25,12 +25,24 @@ describe 'Graph legend', inspect: true do
     let(:data) { {views: views, uniques: uniques} }
 
     it 'includes the titleized names of both series' do
-      expect(inspected_text.strings).to eq ['Views', 'Uniques']
+      expect(inspected_strings).to eq ['Views', 'Uniques']
     end
 
     it 'prints both names on the same text line' do
       lines = inspected_text.positions.map(&:last).uniq
       expect(lines).to be_one
     end
+  end
+
+  it 'can be disabled setting the :legend option to false' do
+    pdf.chart data, options.merge(gridlines: 0, legend: false)
+    expect(inspected_strings).to be_empty
+  end
+
+  it 'can be disabled with Squid.config' do
+    Squid.configure {|config| config.legend = false}
+    pdf.chart data, options.merge(gridlines: 0)
+    Squid.configure {|config| config.legend = true}
+    expect(inspected_strings).to be_empty
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ RSpec.shared_context 'PDF Inspector', inspect: true do
   let(:inspected_line) { PDF::Inspector::Graphics::Line.analyze output }
   let(:inspected_points) { inspected_line.points.each_slice(2) }
   let(:inspected_text) { PDF::Inspector::Text.analyze output }
+  let(:inspected_strings) { inspected_text.strings }
   let(:inspected_rectangle) { PDF::Inspector::Graphics::Rectangle.analyze output }
   let(:data) { {} }
   let(:options) { {} }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,4 +30,5 @@ RSpec.shared_context 'PDF Inspector', inspect: true do
 
   let(:views) { {2013 => 182, 2014 => 46, 2015 => 102} }
   let(:uniques) { {2013 => 110, 2014 => 30, 2015 => 88} }
+  let(:subscribers) { {2013 => 50, 2014 => -30, 2015 => 20} }
 end

--- a/squid.gemspec
+++ b/squid.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency             'prawn', '~> 2.0'
-  spec.add_dependency             'activesupport' # 3 or 4, see gemfiles/
-
+  spec.add_dependency             'activesupport', '~> 4.0' # 3.2 does not have number_to_rounded
   spec.add_development_dependency 'pdf-inspector', '~> 1.2'
   spec.add_development_dependency 'prawn-manual_builder', '~> 0.2.0'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Axis values are now displayed to the left of the graphs.
There are more functionalities to add:

* axis values for multiple series
* measure the widest label, right align the labels and start gridlines from there
* add more formats for labels
* add more details to extract min/max values of each series