### PR TITLE
Modify height removing `cursor` and `float`

### DIFF
--- a/lib/squid/base.rb
+++ b/lib/squid/base.rb
@@ -37,6 +37,10 @@ module Squid
       {valign: :center, overflow: :shrink_to_fit}
     end
 
+    def legend_height
+      15
+    end
+
     # Default font size for text elements (labels, categories, ...)
     def font_size
       8

--- a/lib/squid/configuration.rb
+++ b/lib/squid/configuration.rb
@@ -35,7 +35,7 @@ module Squid
       format:    {default: 'integer', as: -> (value) { value.to_sym }},
       legend:    {default: 'true',    as: -> (value) { true? value }},
       gridlines: {default: '4',       as: -> (value) { value.to_i }},
-      height:    {default: '200',     as: -> (value) { value.to_f }},
+      height:    {default: '250',     as: -> (value) { value.to_f }},
       ticks:     {default: 'true',    as: -> (value) { true? value }},
     }
 

--- a/lib/squid/graph.rb
+++ b/lib/squid/graph.rb
@@ -31,7 +31,7 @@ module Squid
     end
 
     def draw_grid
-      Grid.new(pdf, labels, left: left).draw
+      Grid.new(pdf, labels, grid_options).draw
     end
 
     def draw_baseline
@@ -40,7 +40,11 @@ module Squid
 
     def draw_chart
       min, max = min_max first_series
-      Chart.new(pdf, first_series, left: left, min: min, max: max).draw
+      Chart.new(pdf, first_series, grid_options.merge(min: min, max: max)).draw
+    end
+
+    def grid_options
+      {left: left, height: chart_height, top: chart_top}
     end
 
     def draw_border
@@ -59,6 +63,27 @@ module Squid
     # Returns the width of the left axis
     def left
       @left ||= max_width_of left_labels
+    end
+
+    def chart_height
+      bounds.height - padding_top - padding_bottom
+    end
+
+    def chart_top
+      bounds.top - padding_top
+    end
+
+    # Return the padding between the top of the graph and the grid.
+    # In any case, a padding is present (for values above the top of the grid).
+    # If there is a legend, an equivalent padding is present for the legend.
+    def padding_top
+      legend_height * (legend ? 2 : 1)
+    end
+
+    # Return the padding between the grid and the bottom of the graph.
+    # It is only present if baseline and categories are drawn
+    def padding_bottom
+      baseline ? text_height : 0
     end
 
     # Returns the labels to print in the left axis.

--- a/lib/squid/graph/baseline.rb
+++ b/lib/squid/graph/baseline.rb
@@ -48,7 +48,7 @@ module Squid
 
     # Returns the vertical position of the baseline.
     def y
-      cursor - bounds.height
+      bounds.bottom + text_height
     end
 
     # Returns the height of the tick

--- a/lib/squid/graph/chart.rb
+++ b/lib/squid/graph/chart.rb
@@ -3,7 +3,6 @@ require 'squid/base'
 module Squid
   # Adds the chart components (columns, lines, ...) to the graph.
   class Chart < Base
-
     def draw
       x = left
       data.each do |value|
@@ -18,7 +17,7 @@ module Squid
     # value in the chart. Adds some padding to separate between elements.
     def draw_element(value, x)
       w = width - 2 * element_padding
-      h = height value
+      h = height_per_unit * value.to_f
       fill_rectangle [x + element_padding, zero_y + h], w, h
     end
 
@@ -37,20 +36,14 @@ module Squid
       width / 8
     end
 
-    # Returns the vertical space for a given value.
-    def height(value)
-      height_per_unit * value.to_f
-    end
-
     # Returns the vertical position for the "0" value.
     def zero_y
-      baseline = cursor - bounds.height
-      baseline - @settings[:min] * height_per_unit
+      @settings[:top] - @settings[:height] - @settings[:min] * height_per_unit
     end
 
     # Returns how many points correspond to how many units of the value
     def height_per_unit
-      @h_p_u ||= bounds.height.to_f / (@settings[:max] - @settings[:min])
+      @h_p_u ||= @settings[:height].to_f / (@settings[:max] - @settings[:min])
     end
   end
 end

--- a/lib/squid/graph/grid.rb
+++ b/lib/squid/graph/grid.rb
@@ -13,10 +13,10 @@ module Squid
   private
 
     def each_line
-      y = bounds.top
+      y = @settings[:top]
       data.each.with_index do |labels, index|
         yield y, labels, (index == lines)
-        y -= bounds.height / lines
+        y -= @settings[:height] / lines
       end
     end
 

--- a/lib/squid/graph/legend.rb
+++ b/lib/squid/graph/legend.rb
@@ -9,14 +9,12 @@ module Squid
   class Legend < Base
 
     def draw
-      float do
-        bounding_box [width, cursor+height*2], width: width, height: height do
-          right_margin = bounds.right
-          data.each do |series|
-            right_margin = draw_label series, right_margin
-            right_margin = draw_square series, right_margin
-            right_margin -= label_padding
-          end
+      bounding_box [width, bounds.top], width: width, height: legend_height do
+        right_margin = bounds.right
+        data.each do |series|
+          right_margin = draw_label series, right_margin
+          right_margin = draw_square series, right_margin
+          right_margin -= label_padding
         end
       end
     end
@@ -30,7 +28,8 @@ module Squid
     def draw_label(series, x)
       label = series.to_s.titleize
       x -= width_of label, size: font_size
-      text_box label, at: [x, bounds.top], size: font_size, height: height, valign: :center
+      options = {size: font_size, height: legend_height, valign: :center}
+      text_box label, options.merge(at: [x, bounds.top])
       x
     end
 
@@ -49,29 +48,24 @@ module Squid
       bounds.width/2
     end
 
-    # Restrict the legend to a specific vertical space
-    def height
-      15
-    end
-
     # Ensure the label fits in the height of the legend
     def font_size
-      height/2
+      legend_height/2
     end
 
     # Ensure the square fits in the height of the legend
     def square_size
-      height/3
+      legend_height/3
     end
 
     # The horizontal distance left between the labels of two series
     def label_padding
-      height
+      legend_height
     end
 
     # The horizontal distance left between the squares of two series
     def square_padding
-      height/5
+      legend_height/5
     end
   end
 end

--- a/lib/squid/graph/legend.rb
+++ b/lib/squid/graph/legend.rb
@@ -10,16 +10,22 @@ module Squid
 
     def draw
       bounding_box [width, bounds.top], width: width, height: legend_height do
-        right_margin = bounds.right
-        data.each do |series|
-          right_margin = draw_label series, right_margin
-          right_margin = draw_square series, right_margin
-          right_margin -= label_padding
+        each_series do |x, series|
+          x = draw_label series, x
+          x = draw_square series, x
         end
       end
     end
 
   private
+
+    def each_series
+      x = bounds.right
+      data.each do |series|
+        x = yield x, series
+        x -= label_padding
+      end
+    end
 
     # Writes the name of the series, left-aligned, with a small font size.
     # @param [Symbol, String] series The series to add to the legend

--- a/manual/squid/height.rb
+++ b/manual/squid/height.rb
@@ -1,9 +1,9 @@
-# By default, <code>chart</code> generates charts with a height of 200.
+# By default, <code>chart</code> generates charts with a height of 250.
 #
 # You can use the <code>:height</code> option to manually set the height.
 #
 filename = File.basename(__FILE__).gsub('.rb', '.pdf')
 Prawn::ManualBuilder::Example.generate(filename) do
   data = {views: {2013 => 18.2, 2014 => 4.6, 2015 => 10.2}}
-  chart data, height: 300
+  chart data, height: 350
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -96,9 +96,9 @@ describe Squid::Configuration do
   describe 'height' do
     let(:height) { rand(600).to_f }
 
-    it 'is 200 by default' do
+    it 'is 250 by default' do
       ENV['SQUID_HEIGHT'] = nil
-      expect(config.height).to eq 200.0
+      expect(config.height).to eq 250.0
     end
 
     it 'can be set with the environment variable SQUID_HEIGHT' do

--- a/spec/graph/height_spec.rb
+++ b/spec/graph/height_spec.rb
@@ -3,14 +3,14 @@ require 'spec_helper'
 describe 'Graph height', inspect: true do
   let(:options) { {baseline: false, gridlines: 0} }
 
-  it 'is 200 by default' do
+  it 'is 250 by default' do
     pdf.stroke_horizontal_rule
     pdf.chart one_series, options
     pdf.stroke_horizontal_rule
 
     expect(inspected_points.size).to be 2
     top, bottom = inspected_points.map{|x| x.first.last}
-    expect(top - bottom).to eq 200
+    expect(top - bottom).to eq 250
   end
 
   it 'can be set with the :height option' do
@@ -28,7 +28,7 @@ describe 'Graph height', inspect: true do
     pdf.stroke_horizontal_rule
     pdf.chart one_series, options
     pdf.stroke_horizontal_rule
-    Squid.configure {|config| config.height = 200}
+    Squid.configure {|config| config.height = 250}
 
     expect(inspected_points.size).to be 2
     top, bottom = inspected_points.map{|x| x.first.last}


### PR DESCRIPTION
Now legend and baseline are included inside the height.
Therefore, the height specified by the user now matches exactly the
space taken by the graph, whether legend and baseline are present
or not.