### PR TITLE
Make Travis faster by caching bundles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ notifications:
   email: true
 matrix:
   include:
-  - rvm: 2.1.0
+  - rvm: 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 notifications:
   email: true
 matrix:


### PR DESCRIPTION
See http://docs.travis-ci.com/user/caching/

Travis CI improves from 53 to 16 seconds!

![improvement](https://cloud.githubusercontent.com/assets/7408595/9157371/0a4294d0-3eb0-11e5-9c19-f8f54148fada.png "Improvement")