### PR TITLE
Fix: Round up width_of to make room for text

### DIFF
--- a/lib/squid/graph/legend.rb
+++ b/lib/squid/graph/legend.rb
@@ -33,7 +33,7 @@ module Squid
     # @return [Integer] The updated right-margin (after adding the label)
     def draw_label(series, x)
       label = series.to_s.titleize
-      x -= width_of label, size: font_size
+      x -= width_of(label, size: font_size).ceil
       options = {size: font_size, height: legend_height, valign: :center}
       text_box label, options.merge(at: [x, bounds.top])
       x


### PR DESCRIPTION
See https://github.com/prawnpdf/prawn/issues/903

Specifically, if the label is "Uniques", then the width calculated
as a Float is not big enough to accommodate the text.