### PR TITLE
Fix: don’t draw an axis if the data is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.0.1 - 2015.10.01
+
+* [BUGFIX] Don’t try to draw an axis if the data is empty.
+
 ## 1.0.0 - 2015.08.31
 
 * [FEATURE] Add `chart` method to Prawn::Document to draw graphs.

--- a/lib/squid/axis.rb
+++ b/lib/squid/axis.rb
@@ -39,11 +39,15 @@ module Squid
     end
 
     def min
-      [values.first.min, 0].min if @data.any? && values.first.any?
+      if @data.any? && values.first && values.first.any?
+        [values.first.min, 0].min
+      end
     end
 
     def max
-      [values.last.max, @steps].max if @data.any? && values.last.any?
+      if @data.any? && values.last && values.last.any?
+        [values.last.max, @steps].max
+      end
     end
 
     def values

--- a/lib/squid/version.rb
+++ b/lib/squid/version.rb
@@ -1,3 +1,3 @@
 module Squid
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
A very specific case was raising an error, for instance if data is

    {"organic_views"=>{}, "paid_views"=>{}}

or anything made of empty hashes, and the type is `:stack`.