### PR TITLE
Do not titleize the labels

### DIFF
--- a/lib/squid/graph.rb
+++ b/lib/squid/graph.rb
@@ -36,7 +36,7 @@ module Squid
     end
 
     def draw_legend
-      labels = @data.keys.reverse.map{|key| key.to_s.titleize}
+      labels = @data.keys.reverse.map{|key| key.to_s}
       right = legend.is_a?(Hash) ? legend.fetch(:right, 0) : 0
       @plot.legend labels, right: right, colors: colors, height: legend_height
     end


### PR DESCRIPTION
The keys of the data hash are only used for labeling. So for me it would make more sense to format the keys as i want them to be. For example I want my label to be 'BWK p.a.'. Currently that is not possible.