### PR TITLE
Require Prawn 2.2 and bump to 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## 1.3.2 - unreleased
+## 1.4.0 - 2017.03.15
 
+* [ENHANCEMENT] Require Prawn ~> 2.2.0
 * [ENHANCEMENT] Remove a 'puts' statement left over from development
 
 ## 1.3.0 - 2016.03.01

--- a/lib/squid/version.rb
+++ b/lib/squid/version.rb
@@ -1,3 +1,3 @@
 module Squid
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/spec/squid_spec.rb
+++ b/spec/squid_spec.rb
@@ -6,7 +6,7 @@ describe 'Prawn::Document#chart' do
   let(:data) { {} }
   let(:options) { {legend: false, baseline: false, steps: 0, format: :currency} }
   let(:settings) { options }
-  let(:blue_rgb) { [0.18, 0.341, 0.549] }
+  let(:blue_rgb) { [0.1804, 0.3412, 0.549] }
 
   specify 'given no data, does not plot anything' do
     expect(rectangles_of chart).to be_empty

--- a/squid.gemspec
+++ b/squid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency             'prawn', '~> 2.0'
+  spec.add_dependency             'prawn', '~> 2.2'
   spec.add_dependency             'activesupport', '>= 4.0' # 3.2 does not have ActiveSupport::NumberHelper#number_to_rounded
   spec.add_development_dependency 'pdf-inspector', '~> 1.2'
   spec.add_development_dependency 'prawn-manual_builder', '~> 0.2.0'


### PR DESCRIPTION
This is because the new Prawn version changes the format of RGB colors
from `[0.18, 0.341, 0.549]` to `[0.1804, 0.3412, 0.549]`.