### PR TITLE
Remove support for deprecated Ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   email: true
 matrix:
   include:
-  - rvm: 2.1.5
-    gemfile: gemfiles/Gemfile.activesupport-4.x
   - rvm: 2.2.4
+    gemfile: gemfiles/Gemfile.activesupport-4.x
+  - rvm: 2.4.1
     gemfile: gemfiles/Gemfile.activesupport-5.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 1.4.1 - 2017.09.05
+
+* [ENHANCEMENT] Require Ruby >= 2.2 (since support for 2.1 has ended)
+
 ## 1.4.0 - 2017.03.15
 
 * [ENHANCEMENT] Require Prawn ~> 2.2.0

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ Please proceed to [http://fullscreen.github.io/squid](http://fullscreen.github.i
 How to install
 ==============
 
-Squid requires **Ruby 2.1 or higher**.
+Squid requires **Ruby 2.2 or higher**.
 If used in a Rails project, requires **Rails 4.0 or higher**.
 
-To include in your project, add `gem 'squid', '~> 1.2'` to the `Gemfile` file of your Ruby project.
+To include in your project, add `gem 'squid', '~> 1.4'` to the `Gemfile` file of your Ruby project.
 
 How to generate the manual
 ==========================

--- a/lib/squid/version.rb
+++ b/lib/squid/version.rb
@@ -1,3 +1,3 @@
 module Squid
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/squid.gemspec
+++ b/squid.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/fullscreen/squid'
   spec.license       = 'MIT'
 
-  spec.required_ruby_version = '>= 2.1.0' # 2.0 does not have Numeric#step(by:, to:)
+  spec.required_ruby_version = '>= 2.2.0' # support for 2.1 has ended
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'


### PR DESCRIPTION
See https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended

Also updates Travis to run the latest version of Ruby as well.

See https://travis-ci.org/Fullscreen/squid/builds/272110689