### PR TITLE
Support negative axes

### DIFF
--- a/lib/squid/axis.rb
+++ b/lib/squid/axis.rb
@@ -46,6 +46,7 @@ module Squid
 
     def max
       if @data.any? && values.last && values.last.any?
+        return 0 if min < 0 && values.last.max <= 0
         closest_step_to values.last.max
       end
     end

--- a/spec/axis_spec.rb
+++ b/spec/axis_spec.rb
@@ -99,4 +99,29 @@ describe Squid::Axis do
       it { expect(width).to eq 14 }
     end
   end
+
+  describe '#minmax' do
+    subject(:axis) { Squid::Axis.new series, options }
+    let(:minmax) { axis.minmax }
+
+    describe 'given all-zero series' do
+      let(:series) { [0, 0, 0] }
+      it { expect(minmax).to eq [0, steps] }
+    end
+
+    describe 'given positive series' do
+      let(:series) { [0, 10, 12] }
+      it { expect(minmax).to eq [0, 12] }
+    end
+
+    describe 'given negative series' do
+      let(:series) { [0, -10, -12] }
+      it { expect(minmax).to eq [-12, 0] }
+    end
+
+    describe 'given mixed series' do
+      let(:series) { [0, -10, 12] }
+      it { expect(minmax).to eq [-10, 12] }
+    end
+  end
 end


### PR DESCRIPTION
I had an issue where rendering a series of values <= 0 would still produce an axis label at +4 (or more accurately, whatever `steps` was set to). This change results in a maximum axis label of 0 if all values are <= 0.

Thanks for the library, please let me know if there's anything you'd like me to look at here!