### PR TITLE
Add support for Ruby 3.0

### DIFF
--- a/lib/squid/graph.rb
+++ b/lib/squid/graph.rb
@@ -43,7 +43,7 @@ module Squid
 
     def draw_gridlines
       options = {height: grid_height, count: steps, skip_baseline: baseline}
-      Gridline.for(options).each do |line|
+      Gridline.for(**options).each do |line|
         @plot.horizontal_line line.y, line_width: 0.5, transparency: 0.25
       end
     end
@@ -68,7 +68,7 @@ module Squid
       args = {minmax: axis.minmax, height: grid_height, stack: stack?}
       args[:labels] = items_of labels, skip_first_if: second_axis
       args[:formats] = items_of formats, skip_first_if: second_axis
-      points = Point.for axis.data, args
+      points = Point.for axis.data, **args
       options = {colors: colors, starting_at: (second_axis ? 1: 0)}
       case (second_axis ? :column : type)
         when :point then @plot.points points, options
@@ -97,7 +97,7 @@ module Squid
     def axis(first:, last:)
       series = @data.values[first, last].map(&:values)
       options = {steps: steps, stack: stack?, format: formats[first]}
-      Axis.new(series, options) {|label| @plot.width_of label}
+      Axis.new(series, **options) {|label| @plot.width_of label}
     end
 
     def bottom

--- a/lib/squid/plotter.rb
+++ b/lib/squid/plotter.rb
@@ -74,7 +74,7 @@ module Squid
     end
 
     def points(series, options = {})
-      items(series, options) do |point, w, i, padding|
+      items(series, **options) do |point, w, i, padding|
         x, y = (point.index + 0.5)*w + left, point.y + @bottom
         @pdf.fill_circle [x, y], 5
       end
@@ -83,7 +83,7 @@ module Squid
     def lines(series, options = {})
       x, y = nil, nil
       line_widths = options.delete(:line_widths) { [] }
-      items(series, options) do |point, w, i, padding|
+      items(series, **options) do |point, w, i, padding|
         prev_x, prev_y = x, y
         x, y = (point.index + 0.5)*w + left, point.y + @bottom
         line_width = line_widths.fetch i, 3
@@ -94,14 +94,14 @@ module Squid
     end
 
     def stacks(series, options = {})
-      items(series, options.merge(fill: true)) do |point, w, i, padding|
+      items(series, **options.merge(fill: true)) do |point, w, i, padding|
         x, y = point.index*w + padding + left, point.y + @bottom
         @pdf.fill_rectangle [x, y], w - 2*padding, point.height
       end
     end
 
     def columns(series, options = {})
-      items(series, options.merge(fill: true, count: series.size)) do |point, w, i, padding|
+      items(series, **options.merge(fill: true, count: series.size)) do |point, w, i, padding|
         item_w = (w - 2 * padding)/ series.size
         x, y = point.index*w + padding + left + i*item_w, point.y + @bottom
         @pdf.fill_rectangle [x, y], item_w, point.height

--- a/spec/axis_label_spec.rb
+++ b/spec/axis_label_spec.rb
@@ -9,7 +9,7 @@ describe Squid::AxisLabel do
   let(:width) { 50 }
 
   describe '.for' do
-    subject(:axis_labels) { Squid::AxisLabel.for axis, options }
+    subject(:axis_labels) { Squid::AxisLabel.for axis, **options }
 
     it 'returns an instance for each label, with vertically distributed y between 0 and height' do
       expect(axis_labels.map &:label).to eq labels

--- a/spec/axis_spec.rb
+++ b/spec/axis_spec.rb
@@ -9,7 +9,7 @@ describe Squid::Axis do
   let(:series) { [[-1.0, 9.9, 3.0], [nil, 2.0, -50.0]] }
 
   describe '#labels' do
-    subject(:axis) { Squid::Axis.new series, options }
+    subject(:axis) { Squid::Axis.new series, **options }
     let(:labels) { axis.labels }
 
     describe 'given 0 steps' do
@@ -82,18 +82,18 @@ describe Squid::Axis do
     let(:width) { axis.width }
 
     describe 'given no block, returns 0' do
-      subject(:axis) { Squid::Axis.new series, options }
+      subject(:axis) { Squid::Axis.new series, **options }
       it { expect(width).to be_zero }
     end
 
     describe 'given non-integer values, returns the maximum value of the block' do
-      subject(:axis) { Squid::Axis.new series, options, &block }
+      subject(:axis) { Squid::Axis.new series, **options, &block }
       let(:block) { -> (value) { value.to_i } }
       it { expect(width).to eq 9 }
     end
 
     describe 'given integer values, returns the maximum value, rounded to the closest step' do
-      subject(:axis) { Squid::Axis.new series, options, &block }
+      subject(:axis) { Squid::Axis.new series, **options, &block }
       let(:format) { :integer }
       let(:block) { -> (value) { value.to_i } }
       it { expect(width).to eq 14 }

--- a/spec/gridline_spec.rb
+++ b/spec/gridline_spec.rb
@@ -7,12 +7,12 @@ describe Squid::Gridline do
   let(:skip_baseline) { false }
 
   describe '.for' do
-    subject(:gridlines) { Squid::Gridline.for options }
+    subject(:gridlines) { Squid::Gridline.for **options }
 
     it 'returns +count+ instances, with vertically distributed y between 0 and height' do
       expect(gridlines.map &:y).to eq [100.0, 75.0, 50.0, 25.0, 0.0]
     end
-    
+
     describe 'given skip_baseline: true' do
       let(:skip_baseline) { true }
       it 'skips the last line' do

--- a/spec/point_spec.rb
+++ b/spec/point_spec.rb
@@ -10,7 +10,7 @@ describe Squid::Point do
   let(:series) { [[-10.0, 109.9, 30.0], [nil, 20.0, -50.0]] }
 
   describe '.for' do
-    subject(:points) { Squid::Point.for series, options }
+    subject(:points) { Squid::Point.for series, **options }
 
     it 'calculates the height considering each value within minmax, relative to the height' do
       expect(points.first.map &:height).to eq [-5.0, 54.95, 15.0]


### PR DESCRIPTION
Ruby 3.0 [separates positional from keyword arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/), which renders some calls in the gem not to work anymore (mostly where `options` is used as a Hash instead of keyword arguments). Splatting the hash makes the methods work again.