### PR TITLE
Support min: / max: options for y-axis range

### DIFF
--- a/lib/squid.rb
+++ b/lib/squid.rb
@@ -27,6 +27,8 @@ module Squid
     # @option settings [Numeric] :steps (4) the number of gridlines.
     # @option settings [Boolean] :ticks (true) whether to plot the ticks.
     # @option settings [Symbol] :type (:column) the type of graph.
+    # @option settings [Numeric] :min
+    # @option settings [Numeric] :max
     def chart(data =  {}, settings = {})
       Graph.new(self, data, settings).draw
     end

--- a/lib/squid/axis.rb
+++ b/lib/squid/axis.rb
@@ -7,8 +7,8 @@ module Squid
     include Format
     attr_reader :data
 
-    def initialize(data, steps:, stack:, format:, &block)
-      @data, @steps, @stack, @format = data, steps, stack, format
+    def initialize(data, steps:, stack:, format:, min: nil, max: nil, &block)
+      @data, @steps, @stack, @format, @min, @max = data, steps, stack, format, min, max
       @width_proc = block if block_given?
     end
 
@@ -40,13 +40,13 @@ module Squid
 
     def min
       if @data.any? && values.first && values.first.any?
-        [values.first.min, 0].min
+        @min || [values.first.min, 0].min
       end
     end
 
     def max
       if @data.any? && values.last && values.last.any?
-        closest_step_to values.last.max
+        closest_step_to(@max || values.last.max)
       end
     end
 

--- a/lib/squid/configuration.rb
+++ b/lib/squid/configuration.rb
@@ -36,6 +36,10 @@ module Squid
       -> (value) { value.to_i }
     end
 
+    def self.optional_integer
+      -> (value) { value && value.to_i }
+    end
+
     def self.symbol
       -> (value) { value.to_sym }
     end
@@ -62,6 +66,8 @@ module Squid
       steps:        {as: integer,        default: '4'},
       ticks:        {as: boolean,        default: 'true'},
       type:         {as: symbol,         default: 'column'},
+      min:          {as: optional_integer, default: nil},
+      max:          {as: optional_integer, default: nil},
     }
 
     attr_accessor *ATTRIBUTES.keys

--- a/lib/squid/graph.rb
+++ b/lib/squid/graph.rb
@@ -13,7 +13,7 @@ module Squid
   class Graph
     extend Settings
     has_settings :baseline, :border, :chart, :colors, :every, :formats, :height
-    has_settings :legend, :line_widths, :steps, :ticks, :type, :labels
+    has_settings :legend, :line_widths, :steps, :ticks, :type, :labels, :min, :max
 
     def initialize(document, data = {}, settings = {})
       @data, @settings = data, settings
@@ -96,7 +96,7 @@ module Squid
 
     def axis(first:, last:)
       series = @data.values[first, last].map(&:values)
-      options = {steps: steps, stack: stack?, format: formats[first]}
+      options = {steps: steps, stack: stack?, format: formats[first], min: min, max: max}
       Axis.new(series, options) {|label| @plot.width_of label}
     end
 

--- a/spec/axis_spec.rb
+++ b/spec/axis_spec.rb
@@ -76,6 +76,13 @@ describe Squid::Axis do
         expect(labels).to eq %w(9.9 -5.1 -20 -35 -50)
       end
     end
+
+    describe 'given :min and :max' do
+      let(:options) { {steps: steps, stack: stack?, format: format, min: -500, max: 1000 } }
+      it "uses the give values as first and last label" do
+        expect(labels).to eq ["1,000", "625", "250", "-125", "-500"]
+      end
+    end
   end
 
   describe '#width' do

--- a/spec/squid_spec.rb
+++ b/spec/squid_spec.rb
@@ -241,6 +241,11 @@ describe 'Prawn::Document#chart' do
       it { expect(colors_of(chart).fill_color).to eq [1.0, 0.0, 0.0] }
     end
 
+    describe 'uses a given range with max and min options' do
+      let(:settings) { options.merge(steps: 5, max: 100, min: -100).except(:format) }
+      it { expect(strings_of chart).to eq ["100", "60", "20", "-20", "-60", "-100"] }
+    end
+
     describe 'formats value labels with the value of the :format option' do
       let(:settings) { options.merge label: true, format: :percentage }
       it { expect(strings_of chart).to eq %w(50.0% -30.0% 20.0%) }


### PR DESCRIPTION
I noticed that charts always had `0` as the minimum y-axis value, but I wanted some charts with different ranges. I found a way to add it, what do you think of this change?